### PR TITLE
Rename api key table to yamada_ssh_keys

### DIFF
--- a/app/api/ssh-keys/route.ts
+++ b/app/api/ssh-keys/route.ts
@@ -1,5 +1,7 @@
 import { getApiKeysForUser } from '@/lib/db';
 
+export const dynamic = 'force-dynamic';
+
 export async function GET() {
   const apiKeys = await getApiKeysForUser();
   return Response.json({ apiKeys });

--- a/create-dynamo-tables.ts
+++ b/create-dynamo-tables.ts
@@ -81,12 +81,12 @@ async function main() {
     BillingMode: 'PAY_PER_REQUEST'
   });
 
-  console.log('Creating table: yamada_api_keys');
+  console.log('Creating table: yamada_ssh_keys');
   await createTable({
-    TableName: 'yamada_api_keys',
-    AttributeDefinitions: [{ AttributeName: 'key', AttributeType: 'S' }],
-    KeySchema: [{ AttributeName: 'key', KeyType: 'HASH' }],
-    BillingMode: 'PAY_PER_REQUEST'
+    TableName: 'yamada_ssh_keys',
+      AttributeDefinitions: [{ AttributeName: 'key', AttributeType: 'S' }],
+      KeySchema: [{ AttributeName: 'key', KeyType: 'HASH' }],
+      BillingMode: 'PAY_PER_REQUEST'
   });
 }
 

--- a/lib/db/dynamo-service.ts
+++ b/lib/db/dynamo-service.ts
@@ -221,20 +221,20 @@ export async function createInvitation(inv: NewInvitation) {
 export async function createApiKey(key: NewApiKey) {
   const timestamp = new Date().toISOString();
   await ddb.send(
-    new PutCommand({ TableName: 'yamada_api_keys', Item: { ...key, timestamp } })
+    new PutCommand({ TableName: 'yamada_ssh_keys', Item: { ...key, timestamp } })
   );
 }
 
 export async function deleteApiKey(key: string) {
   await ddb.send(
-    new DeleteCommand({ TableName: 'yamada_api_keys', Key: { key } })
+    new DeleteCommand({ TableName: 'yamada_ssh_keys', Key: { key } })
   );
 }
 
 export async function getApiKeys(userId: number): Promise<ApiKey[]> {
   const res = await ddb.send(
     new ScanCommand({
-      TableName: 'yamada_api_keys',
+      TableName: 'yamada_ssh_keys',
       FilterExpression: 'userId = :u',
       ExpressionAttributeValues: { ':u': userId }
     })


### PR DESCRIPTION
## Summary
- rename `yamada_api_keys` table to `yamada_ssh_keys`
- update DynamoDB service functions with new table name
- force-dynamic API route for SSH keys

## Testing
- `npm test` *(fails: Missing script)*