### PR TITLE
Add BASE_URL prompt to setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Use the included setup script to create your `.env` file:
 pnpm db:setup
 ```
 
+The setup script will ask for your `BASE_URL`. You can also provide it in advance:
+
+```bash
+BASE_URL=https://example.com pnpm db:setup
+```
+
 Run the database migrations and seed the database with a default user and team.
 
 ```bash

--- a/lib/db/setup.ts
+++ b/lib/db/setup.ts
@@ -134,13 +134,24 @@ async function createStripeWebhook(): Promise<string> {
   }
 }
 
+
+async function getBaseUrl(): Promise<string> {
+  console.log('Step 5: Setting BASE_URL');
+  const defaultUrl = 'http://localhost:3000';
+  if (process.env.BASE_URL) {
+    return process.env.BASE_URL;
+  }
+  const answer = await question(`Enter BASE_URL (${defaultUrl}): `);
+  return answer.trim() || defaultUrl;
+}
+
 function generateAuthSecret(): string {
-  console.log('Step 5: Generating AUTH_SECRET...');
+  console.log('Step 6: Generating AUTH_SECRET...');
   return crypto.randomBytes(32).toString('hex');
 }
 
 async function writeEnvFile(envVars: Record<string, string>) {
-  console.log('Step 6: Writing environment variables to .env');
+  console.log('Step 7: Writing environment variables to .env');
   const envContent = Object.entries(envVars)
     .map(([key, value]) => `${key}=${value}`)
     .join('\n');
@@ -155,7 +166,7 @@ async function main() {
   const dbEnv = await getDatabaseEnv();
   const STRIPE_SECRET_KEY = await getStripeSecretKey();
   const STRIPE_WEBHOOK_SECRET = await createStripeWebhook();
-  const BASE_URL = 'http://localhost:3000';
+  const BASE_URL = await getBaseUrl();
   const AUTH_SECRET = generateAuthSecret();
 
   await writeEnvFile({


### PR DESCRIPTION
## Summary
- allow `BASE_URL` to be specified when running `pnpm db:setup`
- document how to set `BASE_URL` during setup

## Testing
- `pnpm build` *(fails: connect EHOSTUNREACH 172.24.0.3:8080)*